### PR TITLE
Now using n-doc 3.1.0

### DIFF
--- a/.github/workflows/build_n-doc_template.yml
+++ b/.github/workflows/build_n-doc_template.yml
@@ -31,7 +31,7 @@ jobs:
 
     # Runs a single command using the runners shell
     - name: Compile documents
-      uses: docker://ndesign/n-doc:3.0.5
+      uses: docker://ndesign/n-doc:3.1.0
       with:
         volumes: /home/runner/work/n-doc_template/n-doc_template":"/data"
         entrypoint: /usr/bin/make

--- a/adv_fsp/fsp_chapter_4.tex
+++ b/adv_fsp/fsp_chapter_4.tex
@@ -153,8 +153,8 @@ wenn Schlüssel erzeugt werden müssen.
 \label{sf.cryptographicservices.hmac}
 
 Die Funktion bietet Implementierungen der Algorithmen für die
-HMAC-Generierung, wobei die Hash-Algorithmen HMAC-SHA-1(-96),
-HMAC-SHA-256(-128) umgesetzt werden (\sfrlink{fcs_cop.1/hmac}).
+HMAC-Generierung, wobei der Hash-Algorithmus
+HMAC-SHA-256(-128) umgesetzt wird (\sfrlink{fcs_cop.1/hmac}).
 
 \subsection{Signaturverifikation}%
 \label{sf.cryptographicservices.sigver}
@@ -171,7 +171,7 @@ Schlüssel für Verschlüsselung und Integritätssicherung im Rahmen der Protoko
 IKE (\secitem{IKE_ENCR} und \secitem{IKE_INTEG}) und ESP (\secitem{ESP_ENCR} und
 \secitem{ESP_INTEG}).
 
-Die Algorithmen PRF-HMAC-SHA-256 und PRF-HMAC-SHA-1 werden vom TOE unterstützt.
+Der Algorithmus PRF-HMAC-SHA-256 wird vom TOE unterstützt.
 
 \rfc{2104} spezifiziert den HMAC-Algorithmus für beliebige Hash-Algorithmen
 \cite{rfc2104}.  FIPS180-4 \cite{FIPS180-4} spezifiziert die verwendeten

--- a/ase/chapter_6/sfr_definitions.tex
+++ b/ase/chapter_6/sfr_definitions.tex
@@ -91,20 +91,18 @@
 
 \sfrdefinition{fcs_cop.1.1/hash}{The TSF shall perform
   \ppassigned{hash value calculation} in accordance with a specified
-  cryptographic algorithm \ppassigned{SHA-1, SHA-256,}
+  cryptographic algorithm \ppassigned{\stdeleted{SHA-1}, SHA-256,}
   \stassigned[list of SHA-2 Algorithms with more than 256 bit
   size]{SHA-512} and cryptographic key sizes \ppassigned{none} that
   meet the following: \ppassigned{FIPS PUB 180-4
     \autocite{FIPS180-4}}.}
 
-\sfrsubsection{fcs_cop.1/hmac}
-\sfrdefinition{fcs_cop.1.1/hmac}{The TSF shall perform
-  \ppassigned{HMAC value generation and verification} in accordance
-  with a specified cryptographic algorithm \ppassigned{HMAC with
-    SHA-1,} \stassigned[list of SHA-2 Algorithms with 256bit size or
-  more]{SHA-256} and cryptographic key sizes \stassigned[cryptographic
-  key sizes]{160 and 256 bit} that meet the following:
-  \ppassigned{FIPS PUB 180-4 \autocite{FIPS180-4},
+\sfrsubsection{fcs_cop.1/hmac} \sfrdefinition{fcs_cop.1.1/hmac}{The TSF shall
+  perform \ppassigned{HMAC value generation and verification} in accordance with
+  a specified cryptographic algorithm \ppassigned{HMAC with \stdeleted{SHA-1},}
+  \stassigned[list of SHA-2 Algorithms with 256bit size or more]{SHA-256} and
+  cryptographic key sizes \stassigned[cryptographic key sizes]{160 and 256 bit}
+  that meet the following: \ppassigned{FIPS PUB 180-4 \autocite{FIPS180-4},
     RFC~2404 \autocite{rfc2404}, RFC~4868 \autocite{rfc4868}, RFC~5996
     \autocite{rfc5996}}.}
 
@@ -114,10 +112,10 @@
 
 \sfrdefinition{fcs_ckm.1.1}{The TSF shall generate cryptographic keys in
   accordance with a specified cryptographic key generation algorithm
-  \stassigned[cryptographic key generation algorithm]{PRF-HMAC-SHA1,
-    PRF-HMAC-SHA256} and specified cryptographic key sizes
-  \stassigned[cryptographic key sizes]{256~bit} that meet the following:
-  \ppassigned{TR-03116 \autocite{TR03116}}.\par
+  \stassigned[cryptographic key generation algorithm]{PRF-HMAC-SHA256} and
+  specified cryptographic key sizes \stassigned[cryptographic key
+  sizes]{256~bit} that meet the following: \ppassigned{TR-03116
+    \autocite{TR03116}}.\par
   \strefined{The following algorithms and preferences are supported for TLS key
     negotiation}
   \begin{sfritemize}

--- a/ase/st-common-macros.tex
+++ b/ase/st-common-macros.tex
@@ -3,7 +3,7 @@
 \newcommand{\citepp}{\autocite{\thispp}}
 
 \newcommand{\stformat}[1]{\textcolor{blue}{#1}}
-\newcommand{\ppformat}[1]{\uline{#1}}
+\newcommand{\ppformat}[1]{\underLine{#1}}
 
 \makeatletter
 \newcommand{\isempty}[2]{%
@@ -15,9 +15,9 @@
 \newcommand{\strefined}[2][]{\stformat{\textbf{#2}}\isnotempty{#1}{\footnote{Refinement: \emph{#1}}}}
 \newcommand{\stassigned}[2][]{\stformat{#2}\isnotempty{#1}{\footnote{Assignment: \emph{#1}}}}
 \newcommand{\stselected}[2][]{\stformat{\emph{#2}}\isnotempty{#1}{\footnote{Selection: \emph{#1}}}}
-\newcommand{\stdeleted}[2][]{\textbf{\stformat{\sout{#2}}}\isnotempty{#1}{\footnote{Deletion: \emph{#1}}}}
+\newcommand{\stdeleted}[2][]{\textbf{\stformat{\strikeThrough{#2}}}\isnotempty{#1}{\footnote{Deletion: \emph{#1}}}}
 \newcommand{\pprefined}[1]{\textbf{#1}}
-\newcommand{\ppdeleted}[1]{\textbf{\sout{#1}}}
+\newcommand{\ppdeleted}[1]{\textbf{\strikeThrough{#1}}}
 \newcommand{\ppassigned}[1]{\ppformat{#1}}
 \newcommand{\ppselected}[1]{\ppformat{\textit{#1}}}
 

--- a/ase/st_chapter_7_asetss.tex
+++ b/ase/st_chapter_7_asetss.tex
@@ -109,7 +109,7 @@ verschiedene Zwecke verwendet, u.a. beim TLS-Verbindungsaufbau
 
 \minisec{Hash-Algorithmen}
 
-Die Funktion bietet Implementierungen für die Hash-Algorithmen SHA-1,
+Die Funktion bietet Implementierungen für die Hash-Algorithmen
 SHA-256 und SHA-512. Im Kontext von TLS implementiert der TOE außerdem
 SHA-384 für bestimmte Cipher Suites.
 
@@ -118,8 +118,7 @@ SHA-384 für bestimmte Cipher Suites.
 \minisec{HMAC Generierung}
 
 Die Funktion bietet darüber hinaus Algorithmen für die HMAC-Generierung, wobei
-die genannten Hash-Algorithmen zum Tragen kommen: HMAC-SHA-1(-96),
-HMAC-SHA-256(-128).
+der genannte Hash-Algorithmus zum Tragen kommt: HMAC-SHA-256(-128).
 
 \umgesetztesfr{\sfrlink{fcs_cop.1/hmac}}
 

--- a/common/common-packages.tex
+++ b/common/common-packages.tex
@@ -8,7 +8,7 @@
 \usepackage{booktabs}
 \usepackage{enumitem}
 \usepackage{scrtime}
-\usepackage[normalem]{ulem}
+\usepackage{lua-ul}
 \usepackage{color}
 \usepackage{tikz}
 \usetikzlibrary{patterns}

--- a/runmake.sh
+++ b/runmake.sh
@@ -1,4 +1,4 @@
 #/bin/bash
 
-docker run --rm  --volume $(pwd):/data ndesign/n-doc:3.0.5 make -j4 delivery
+docker run --rm  --volume $(pwd):/data ndesign/n-doc:3.1.0 make -j4 delivery
 


### PR DESCRIPTION
Switched to lua-ul for underlining. Now able to combine underline and strikethrough. See FCS_COP.1/Hash for an example