### PR TITLE
Fixed latexmk max iterations issue

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1,11 +1,10 @@
-TEXMFCACHEDIR  = ./.texmfcache
 LATEXMK        = latexmk $(LATEXMKFLAGS)
 CLEANFLAGS     = -C
 
 .PHONY: snippets wsdpdf clean FORCE_MAKE
 
 $(MASTER) : wsdpdf FORCE_MAKE
-	TEXMFCACHE=$(TEXMFCACHEDIR) $(LATEXMK)
+	$(LATEXMK)
 
 wsdpdf: 
 	../scripts/transform-wsd.sh pdf $(shell pwd)

--- a/common/latexmkrc
+++ b/common/latexmkrc
@@ -1,3 +1,5 @@
+$hash_calc_ignore_pattern{'luc'}='^';
+
 push @generated_exts, "lol", "run.xml", 'glo', 'gls', 'glg', 'acn', 'acr', 'alg', "xdy", "appnote";
 
 $pdf_mode = 4; $postscript_mode = $dvi_mode = 0;


### PR DESCRIPTION
Have latexmk ignore the font cache updates when recognizing dependencies. See
also https://tug.org/pipermail/tex-live/2022-March/047948.html