### PR TITLE
Use autoref for references

### DIFF
--- a/adv_fsp/chapter_3/ls_lan.tex
+++ b/adv_fsp/chapter_3/ls_lan.tex
@@ -4,10 +4,10 @@
 
 \lslan{} is a logical interface to the IT products in the LAN. It is accessible
 via the physical interface \intf{PS.LAN}. The interface comprises the protocols
-listed in \tableref{tab:ls.lan.protocols-ports} together with their port
-numbers. \figureref{fig:tsfi.ls.lan.protocols} depicts the protocols that
+listed in \autoref{tab:ls.lan.protocols-ports} together with their port
+numbers. \autoref{fig:tsfi.ls.lan.protocols} depicts the protocols that
 contribute to the security aspects of the TSFI (see also the introductory
-remarks in \chapterref{tsfi.ls}.
+remarks in \autoref{tsfi.ls}.
 
 \begin{description}
 \item[Ethernet] for the data link layer,
@@ -18,7 +18,7 @@ remarks in \chapterref{tsfi.ls}.
 \item[HTTP\_Mgmt] HTTP for access to the management interface.
 \end{description}
 
-\tableref{tab:ls.lan.protocols-ports} lists protocols and their ports in more
+\autoref{tab:ls.lan.protocols-ports} lists protocols and their ports in more
 detail. Figure~\vref{fig:tsfi.ls.lan.protocols} shows the protocols of interface
 \lslan{} in relation to each other and to the TCP/IP layer model.
 
@@ -180,7 +180,7 @@ kernel provides the protocol implementation.
 
 \lslantls{} is used to secure the communications to other IP products in the
 LAN. TLS provides confidentiality and integrity to the connections. An overview
-of the TLS connections of the TOE in listed in \tableref{tab:tlsconnections}.
+of the TLS connections of the TOE in listed in \autoref{tab:tlsconnections}.
 
 \calledenforcingsfr{ls.lan.tls}
 
@@ -192,7 +192,7 @@ of the TLS connections of the TOE in listed in \tableref{tab:tlsconnections}.
 
 The implementation of TLS fulfills the requirements from \rfc[c]{5246}. The
 description of the TLS implementation and all TLS connections of the TOE are
-documented in \sectref{sf.tls}.
+documented in \autoref{sf.tls}.
 
 \tsfiactions{tsfi.ls.lan.tls}
 

--- a/adv_fsp/chapter_3/ls_wan.tex
+++ b/adv_fsp/chapter_3/ls_wan.tex
@@ -2,10 +2,10 @@
 
 \lswan{} is a logical interface to the IT products in the WAN. It is 
 accessible via the physical interface \intf{PS.WAN}. The interface comprises the
-protocols listed in \tableref{tab:ls.lwan.protocols-ports} together with their
-port numbers. \figureref{fig:tsfi.ls.lwan.protocols} depicts the protocols that
+protocols listed in \autoref{tab:ls.lwan.protocols-ports} together with their
+port numbers. \autoref{fig:tsfi.ls.lwan.protocols} depicts the protocols that
 contribute to the security aspects of the TSFI (see also the introductory
-remarks in \chapterref{tsfi.ls}.
+remarks in \autoref{tsfi.ls}.
 
 
 \afterpage{%
@@ -165,7 +165,7 @@ ESP provides authenticity, integrity and confidentiality for the transmitted
 data. Separate algorithms for encryption and integrity protection are used. The
 negotiated SA including the required keys and algorithm are used to secure the
 and IP packets sent over the tunnel. ESP headers have the structure shown in
-\figureref{fig:tsfi.ls.wan.ipsec.esp.header} (see also
+\autoref{fig:tsfi.ls.wan.ipsec.esp.header} (see also
 \cite[Figure~2]{rfc4303}).
 
 

--- a/adv_fsp/fsp_chapter_4.tex
+++ b/adv_fsp/fsp_chapter_4.tex
@@ -168,7 +168,7 @@ areas with null bytes.
 
 The TOE implements a TLS server in protocol version~1.2 according to
 \rfc[c]{5246}. All TLS connections and their parameters are listed in
-\appendixref{appendix.tls}.
+\autoref{appendix.tls}.
 
 
 % !TEX root = adv_fsp

--- a/adv_tds/module/cryptsystem/algorithms.tex
+++ b/adv_tds/module/cryptsystem/algorithms.tex
@@ -29,12 +29,12 @@ This process calculates HMAC.
 \moduleinterfaceprovided{int.cryptsystem.algorithms.gethash}
 
 This interface triggers the hash value calculation (see
-\sectref{prc.cryptsystem.algorithms.hash})
+\autoref{prc.cryptsystem.algorithms.hash})
 
 \moduleinterfaceprovided{int.cryptsystem.algorithms.gethmac}
 
 This interface triggers the HMAC calculation (see
-\sectref{prc.cryptsystem.algorithms.hmac})
+\autoref{prc.cryptsystem.algorithms.hmac})
 
 
 

--- a/adv_tds/module/cryptsystem/keymgmt.tex
+++ b/adv_tds/module/cryptsystem/keymgmt.tex
@@ -31,22 +31,22 @@ Keys are destroyed by overwriting the data with pseudo-random numbers. Module
 \moduleinterfaceprovided{int.cryptsystem.keymgmt.createkey}
 
 This interface is used to create a key pair (see
-\sectref{prc.cryptsystem.keymgmt.genkey}).
+\autoref{prc.cryptsystem.keymgmt.genkey}).
 
 \moduleinterfaceprovided{int.cryptsystem.keymgmt.destroykey}
 
-This interface is used to destroy a key (see \sectref{prc.cryptsystem.keymgmt.destroykey}).
+This interface is used to destroy a key (see \autoref{prc.cryptsystem.keymgmt.destroykey}).
 
 \moduleinterfacerequired{int.cryptsystem.rng.creaternd}
 
 The interface \tdslink[fq]{int.selfprotect.memory.cleanup} is required for
-generating random numbers (see \sectref{prc.cryptsystem.keymgmt.genkey})
+generating random numbers (see \autoref{prc.cryptsystem.keymgmt.genkey})
 
 \moduleinterfacerequired{int.selfprotect.memory.cleanup}
 
 The interface \tdslink[fq]{int.selfprotect.memory.cleanup} is required for
 securely erasing the memory during key deletion (see
-\sectref{prc.cryptsystem.keymgmt.destroykey}).
+\autoref{prc.cryptsystem.keymgmt.destroykey}).
 
 
 

--- a/adv_tds/module/cryptsystem/rng.tex
+++ b/adv_tds/module/cryptsystem/rng.tex
@@ -23,7 +23,7 @@ This process generates $n$ random bytes.
 \moduleinterfaceprovided{int.cryptsystem.rng.creaternd}
 
 This interface is provided to create random numbers (see
-\sectref{prc.cryptsystem.rng.creaternd}).
+\autoref{prc.cryptsystem.rng.creaternd}).
 
 
 

--- a/adv_tds/module/ntpclient/core.tex
+++ b/adv_tds/module/ntpclient/core.tex
@@ -25,7 +25,7 @@ via \tsfi{ls.wan.ntp}.
 \moduleinterfaceprovided{int.ntpclient.core.synctime}
 
 This interface can be called by other modules of the TOE to initiate
-synchronization of the system clock (see \sectref{prc.ntpclient.core.sync}).
+synchronization of the system clock (see \autoref{prc.ntpclient.core.sync}).
 
 % !TEX root = "../../adv_tds"
 

--- a/adv_tds/module/selfprotect/memory.tex
+++ b/adv_tds/module/selfprotect/memory.tex
@@ -23,7 +23,7 @@ via \tdslink[fq]{int.cryptsystem.rng.creaternd}.
 
 \moduleinterfaceprovided{int.selfprotect.memory.cleanup}
 
-This interface triggers the memory sanitization (see \sectref{prc.selfprotect.memory.wipemem}). 
+This interface triggers the memory sanitization (see \autoref{prc.selfprotect.memory.wipemem}). 
 
 
 

--- a/adv_tds/module/selfprotect/selftest.tex
+++ b/adv_tds/module/selfprotect/selftest.tex
@@ -23,7 +23,7 @@ periodically every 24 hours. The process can also be called by an administrator.
 \moduleinterfaceprovided{int.selfprotect.selftest.runtest}
 
 This interface calls the self test (see
-\sectref{prc.selfprotect.selftest.runselftest}).
+\autoref{prc.selfprotect.selftest.runselftest}).
 
 
 

--- a/adv_tds/module/vpn/cert.tex
+++ b/adv_tds/module/vpn/cert.tex
@@ -24,7 +24,7 @@ calculated by calling the function
 \moduleinterfaceprovided{int.vpn.cert.checkcert}
 
 This interface is called to check the certificate of a VPN concentrator (see
-\sectref{prc.vpn.cert.checkcert}).
+\autoref{prc.vpn.cert.checkcert}).
 
 \moduleinterfacerequired{int.cryptsystem.algorithms.gethash}
 

--- a/adv_tds/module/vpn/core.tex
+++ b/adv_tds/module/vpn/core.tex
@@ -28,11 +28,11 @@ This process opens a connection to the VPN concentrator.
 
 \moduleinterfaceprovided{int.vpn.core.connect}
 
-This interface triggers the creation of a new VPN connection (see \sectref{prc.vpn.core.connect}).
+This interface triggers the creation of a new VPN connection (see \autoref{prc.vpn.core.connect}).
 
 \moduleinterfaceprovided{int.vpn.core.disconnect}
 
-This interface closes the VPN connection (see \sectref{prc.vpn.core.disconnect}).
+This interface closes the VPN connection (see \autoref{prc.vpn.core.disconnect}).
 
 \moduleinterfacerequired{int.vpn.cert.checkcert}
 

--- a/adv_tds/user_macros.tex
+++ b/adv_tds/user_macros.tex
@@ -55,7 +55,7 @@
 
 \newcommand{\generatesfrtable}[1]{%
   \noindent{}\ndoc@modulesfrtable{}
-  \tableref{tab:#1.sfr}. \ndoc@themoduleis{} \getModuleStatus{#1}. \par{}
+  \autoref{tab:#1.sfr}. \ndoc@themoduleis{} \getModuleStatus{#1}. \par{}
   \captionsetup[table]{list=no}
   \begin{table}[htb]
     \centering
@@ -81,7 +81,7 @@
   \end{longtable}
 }
 
-\newcommand{\generatesfrsubsystable}[1]{\ndoc@subsystemsfrtable{} \tableref{tab:#1.sfr.enf}, \tableref{tab:#1.sfr.sup}. \par
+\newcommand{\generatesfrsubsystable}[1]{\ndoc@subsystemsfrtable{} \autoref{tab:#1.sfr.enf}, \autoref{tab:#1.sfr.sup}. \par
   \captionsetup[table]{list=no}
   \begin{table}[p]
     \centering
@@ -98,7 +98,7 @@
   \captionsetup[table]{list=yes}
 }
 
-\newcommand{\generatebundletable}[1]{\ndoc@bundlesformodules{} \tableref{tab:#1.bundles}
+\newcommand{\generatebundletable}[1]{\ndoc@bundlesformodules{} \autoref{tab:#1.bundles}
   \captionsetup[table]{list=no}
   \begin{table}[htb]
     \centering

--- a/ase/chapter_6/sfr_definitions.tex
+++ b/ase/chapter_6/sfr_definitions.tex
@@ -160,7 +160,7 @@
 
 \applicationnote{\sfr{ftp_itc.1/tls}}{\label{appnote:brainpool} The TOE supports
   key exchange with elliptic curves.The supported curves are list in
-  \tableref{tab:elliptic-curves}.}
+  \autoref{tab:elliptic-curves}.}
 
 
 \sfrsubsection{fpt_tdc.1/tls.zert}
@@ -194,7 +194,7 @@
 
 This section contains security requirements that are defined in addition to the
 Protection Profile. The requirements are extended by the component
-\sfr{fcs_rng.1/hashdrbg} defined in \chapterref{comp.pp-fcsrng}.
+\sfr{fcs_rng.1/hashdrbg} defined in \autoref{comp.pp-fcsrng}.
 
 \sfrsubsection{fcs_rng.1/hashdrbg}
 

--- a/ase/chapter_6/sfr_ratio_dependencies.tex
+++ b/ase/chapter_6/sfr_ratio_dependencies.tex
@@ -1,7 +1,7 @@
 \hrefsubsection{sfr.ratio.ak.dep}{Erklärung der Abhängigkeiten der SFR des
   TOE}
 
-Die Abhängigkeiten der in \sectref{sfr.ak} aufgestellten funktionalen
+Die Abhängigkeiten der in \autoref{sfr.ak} aufgestellten funktionalen
 Sicherheitsanforderungen sind erfüllt. Es gelten dieselben Auflösungen
 von Abhängigkeiten, wie sie im Schutzprofil
 \autocite[Abschnitt~6.5.2]{\thispp} beschrieben sind.

--- a/ase/mapping_legende.tex
+++ b/ase/mapping_legende.tex
@@ -1,6 +1,6 @@
 \hrefchapter{appendix.mappinglegende}{Erklärung der tabellarischen Darstellung}
 
-\tableref{tab:o.mappinglegende} zeigt die in den Tabellen dieses
+\autoref{tab:o.mappinglegende} zeigt die in den Tabellen dieses
 Dokuments verwendeten Symbole. Diese kommen in allen Tabellen zum
 Einsatz, in denen Entitäten der Common Criteria aufeinander abgebildet
 werden.

--- a/ase/st_chapter_1_intro.tex
+++ b/ase/st_chapter_1_intro.tex
@@ -77,7 +77,7 @@ The TOE has custom made hardware\dots{}
 
 All interfaces of the \thisproduct{} are physically placed on the case of the
 device. The interfaces of the TOE are visible in the pictures in
-\figureref{fig:intro.desc.case}.
+\autoref{fig:intro.desc.case}.
 
 \begin{description}
 \item[\intf{PS.LAN}] is the interface to the LAN\dots
@@ -108,7 +108,7 @@ The TOE consists of the following subsystems:
 \hrefsubsection{intro.desc.scope}{Physical Scope of the TOE}
 
 The physical scope of the TOE comprises the components listed in
-\tableref{tab:intro.desc.scope}.
+\autoref{tab:intro.desc.scope}.
 
 \begin{table}[htb]
   \centering

--- a/ase/st_chapter_2_conformance-claims.tex
+++ b/ase/st_chapter_2_conformance-claims.tex
@@ -25,7 +25,7 @@ Profile.
 \hrefsection{conf.package}{Package Conformance Claim}
 
 The Protection Profile requires assurance level EAL3, augmented by the
-components listed in \tableref{tab:conf.eal3plus}. This Security Target claims
+components listed in \autoref{tab:conf.eal3plus}. This Security Target claims
 Conformance to exactly these packages. This conformance is refered to as „EAL3+“
 and is package-augmented to EAL3.
 
@@ -70,7 +70,7 @@ that are required by \autocite{\thispp}.
   Target are marked clearly.
 \end{description}
 
-\chapterref{comp} describes the functional requirement extending CC~Part~2
+\autoref{comp} describes the functional requirement extending CC~Part~2
 \autocite{CCPart2}. There are no requirements that extend CC~Part~3
 \autocite{CCPart3}.
 

--- a/ase/st_chapter_4_security-objectives.tex
+++ b/ase/st_chapter_4_security-objectives.tex
@@ -39,7 +39,7 @@
   Objectives}
 
 The mapping of threats, OSPs and assumptions to objectives is the same as in the
-Protection Profile \citepp{}. \tableref{tab:o.mapping} is a rendition of the
+Protection Profile \citepp{}. \autoref{tab:o.mapping} is a rendition of the
 table in the Protection Profile.
 
 \afterpage{%
@@ -55,7 +55,7 @@ table in the Protection Profile.
 \hrefsubsection{obj.toe.ratio.changes}{Explanation of deviations from the Proctection Profile}
 
 For all unmodified relations that are taken from the Proctection Profile (marked
-with ``\tcheck{}'' in \tableref{tab:o.mapping}), the explanations are valid in
+with ``\tcheck{}'' in \autoref{tab:o.mapping}), the explanations are valid in
   this Security Target.
   
 \hrefsubsubsection{obj.toe.ratio.threats}{Defense against the Threats by the Objectives}

--- a/ase/st_chapter_6_sfr-definition.tex
+++ b/ase/st_chapter_6_sfr-definition.tex
@@ -14,7 +14,7 @@ the ST, the information is given.
 \hrefsubsection{sfr.intro.notc}{Notation}
 
 The typographic styles for the operations of the SFR are described in
-\tableref{tab:sfr.intro.notc}. Deletions in the ST are always accompanied by an
+\autoref{tab:sfr.intro.notc}. Deletions in the ST are always accompanied by an
 explanation why the deletion is necessary.
 
 \begin{table}[htb]
@@ -44,7 +44,7 @@ explanation why the deletion is necessary.
 
 The modellings of the Protection Profile \citepp{} are valid in this Security
 Target. In addition to these modellings, this Security Target assumes the
-subjects, objects, attributes and operations in \tableref{tab:sfr.intro.model}.
+subjects, objects, attributes and operations in \autoref{tab:sfr.intro.model}.
 
 \begin{table}[htb]
   \centering{}
@@ -74,22 +74,22 @@ Profile \citepp{}.
 \hrefsubsection{sfr.ratio.overview}{Overview of the coverage of SFR}
 
 This Security Target adopts the mapping of objectives to SFR as defined in the
-Protection Profile. \tableref{tab:sfr.ratio.sfrtoobjmapping} shows these
+Protection Profile. \autoref{tab:sfr.ratio.sfrtoobjmapping} shows these
 relations.
 
 \input{../ase/chapter_6/mapping_sfr_to_objectives}%
 
 \hrefsubsection{sfr.ratio.dep}{SFR Dependency Rationale}
 
-The dependencies of the security functional requirements in \sectref{sfr.def}
+The dependencies of the security functional requirements in \autoref{sfr.def}
 are fulfilled. This Security Target assumes the same resolutions as defined in
 the Protection Profile in \citepp[Section~6.4.2]{}.
 
-The extended component \secitem{FCS_RNG.1} defined in \sectref{comp.pp-fcsrng}
+The extended component \secitem{FCS_RNG.1} defined in \autoref{comp.pp-fcsrng}
 has no dependencies that need to be resolved.
 
-\tableref{tab:sfr.subjobj2sfr} and \tableref{tab:sfr.sfr2subjobj} show the
-relations of the subjects defined in \tableref{tab:sfr.intro.model} to the SFR.
+\autoref{tab:sfr.subjobj2sfr} and \autoref{tab:sfr.sfr2subjobj} show the
+relations of the subjects defined in \autoref{tab:sfr.intro.model} to the SFR.
 
 \clearpage{}
 

--- a/ase/st_chapter_7_asetss.tex
+++ b/ase/st_chapter_7_asetss.tex
@@ -115,8 +115,8 @@ RSASSA-PSS.
 
 \hrefsection{sf.relationtosfr}{Relation of SFR to SF}
 
-\tableref{tab:sf.mapping} shows the relation between the SFR defined in
-\sectref{sfr.def} and the SF defined in this chapter.
+\autoref{tab:sf.mapping} shows the relation between the SFR defined in
+\autoref{sfr.def} and the SF defined in this chapter.
 
 \input{../ase/chapter_7/mapping_sfr_to_sf}
 

--- a/ate_cov/ate_cov.tex
+++ b/ate_cov/ate_cov.tex
@@ -53,9 +53,9 @@
 This document is the test coverage \secitemformat{ATE\_COV} for
 \thisproductlong{}. The tables in the following sections show the TOE's test
 coverage. The tables show different representations of the same
-data. \sectref{tests} lists each test case and sets it into relation to the TDS
+data. \autoref{tests} lists each test case and sets it into relation to the TDS
 module, the SFR and TSFI, that are covered by this test case. Before that, the
-tables in \sectref{summary} show summaries: The number of test cases per TDS
+tables in \autoref{summary} show summaries: The number of test cases per TDS
 module, per SFR and per TSFI. All tables are based on the entities and relations
 defined in the database \filename{mauvecorp\_vpn\_client.db}. Further quieries
 in the evaluation process can be generated from the tables \code{testcases},
@@ -65,9 +65,9 @@ in the evaluation process can be generated from the tables \code{testcases},
 % Das vorliegende Dokument ist die \secitemformat{ATE\_COV} zu
 % \thisproductlong{}. Die Tabellen in den folgenden Abschnitten zeigen die
 % Testabdeckung des TOE. Dabei werden dieselben Daten unterschiedlich
-% aufbereitet. \sectref{tests} listet jeden Testfall auf und benennt dazu das
+% aufbereitet. \autoref{tests} listet jeden Testfall auf und benennt dazu das
 % TDS-Modul, die SFR und die TSFI, die von diesem Testfall abgedeckt werden. Zuvor
-% zeigen die Tabellen in \sectref{summary} Zusammenfassungen an: Die Anzahl der
+% zeigen die Tabellen in \autoref{summary} Zusammenfassungen an: Die Anzahl der
 % Testfälle pro TDS-Modul, pro SFR und pro TSFI. Alle Tabellen basieren auf
 % Abfragen der Datenbank \filename{mauvecorp\_vpn\_client.db}. Weiter gehende
 % Abfragen für den Evaluationsprozess können daraus erstellt werden. Die

--- a/common/common-macros.tex
+++ b/common/common-macros.tex
@@ -46,15 +46,6 @@
 % Macro for file names
 \newcommand{\filename}[1]{{\narrowfilefont #1}}
 
-% Links to figures, tables, sections, chapters, appendices
-% Most translations are read from the translation package's dictionary
-\newcommand{\figureref}[1]{\hyperref[#1]{\GetTranslation{Figure}~\ref*{#1}}}
-\newcommand{\tableref}[1]{\hyperref[#1]{\GetTranslation{Table}~\ref*{#1}}}
-\newcommand{\listref}[1]{\hyperref[#1]{\GetTranslation{Listing}~\ref*{#1}}}
-\newcommand{\sectref}[1]{\hyperref[#1]{\GetTranslation{Section}~\ref*{#1}}}
-\newcommand{\chapterref}[1]{\hyperref[#1]{\GetTranslation{Chapter}~\ref*{#1}}}
-\newcommand{\appendixref}[1]{\hyperref[#1]{\GetTranslation{Appendix}~\ref*{#1}}}
-
 % Macros for headlines. Creates a hypertext anchor in addition to the \label
 
 % These versions of the command can be called with a star "*", so that headlines

--- a/common/notation.tex
+++ b/common/notation.tex
@@ -6,7 +6,7 @@ seem. Occasionally, the same term is used on different levels of abstraction. It
 is not always possible to determine that level at first glance. For example, a
 term can be both a keyword taken from the specification and the name of a
 variable in the code. Typographic consistency supports the reader in determining
-the level of abstraction. The explanations in \tableref{tab:intro.notc} shall
+the level of abstraction. The explanations in \autoref{tab:intro.notc} shall
 motivate the differentiation.
 
 Subsystems and modules are separated by a double colon, as in

--- a/common/tls_appendix.tex
+++ b/common/tls_appendix.tex
@@ -2,8 +2,8 @@
 
 The Protection Profiles defines the cipher suites required for TLS
 connections. The TOE uses provides exactly those cipher suites and no other.
-\tableref{tab:ciphersuites} lists these cipher
-suites. \tableref{tab:elliptic-curves} lists the elliptic curves used for ECDHE.
+\autoref{tab:ciphersuites} lists these cipher
+suites. \autoref{tab:elliptic-curves} lists the elliptic curves used for ECDHE.
 
 \begin{table}[htb]
   \centering
@@ -42,8 +42,8 @@ suites. \tableref{tab:elliptic-curves} lists the elliptic curves used for ECDHE.
 
 The TOE communicates with other trusted IT products over secure
 connections. Integrity and confidentiality of these connections is ensured by
-TLS~v1.2. \tableref{tab:tlsconnections} lists all connections the TOE can
-participate in. \tableref{tab:tlslegende} describes the columns of this table.
+TLS~v1.2. \autoref{tab:tlsconnections} lists all connections the TOE can
+participate in. \autoref{tab:tlslegende} describes the columns of this table.
 
 
 \begin{table}[htb]

--- a/common/tsfi.tex
+++ b/common/tsfi.tex
@@ -5,13 +5,13 @@ The TOE provides the logical interfaces described in the protection profile \aut
 \item[\hypertarget{tsfi.ls.lan}{\intf{LS.LAN}}] is the TOE's interface to the
   local area network of the operating environment. In addition to the interfaces
   described in the protection profile, there are further protocol specific
-  interfaces described here. \tableref{tab:tsfi.ls.lan} lists these logical
+  interfaces described here. \autoref{tab:tsfi.ls.lan} lists these logical
   interfaces.
 
 \item[\hypertarget{tsfi.ls.wan}{\intf{LS.WAN}}] is the TOE's interface to the
   wide area network of the operating environment, the Internet. In addition to
   the interfaces described in the protection profile, there are further protocol
-  specific interfaces described here. \tableref{tab:tsfi.ls.wan} lists these
+  specific interfaces described here. \autoref{tab:tsfi.ls.wan} lists these
   logical interfaces.
  
 \item[\hypertarget{tsfi.ls.led}{\intf{LS.LED}}] represents the logical interface


### PR DESCRIPTION
Replaced custom macros such as \sectref, \tableref, \figureref etc. with autoref.