### PR TITLE
Enable versioning with more than major.minor version

### DIFF
--- a/scripts/release_documents.sh
+++ b/scripts/release_documents.sh
@@ -43,7 +43,7 @@ function get_version() {
 function get_next_version() {
     current=$1
     let minorversion=${current##*.}
-    majorversion=${current%%.*}
+    majorversion=${current%.*}
     let minorversion++
     echo ${majorversion}.${minorversion}-SNAPSHOT
 }


### PR DESCRIPTION
Allows for semantic versioning in document types. Only the last segment of the version is incremented.