### PR TITLE
Add release packages

### DIFF
--- a/config/n-doc_bash_completions.sh
+++ b/config/n-doc_bash_completions.sh
@@ -6,7 +6,7 @@ function list_documents() {
 
 function _release-documents_completions()
 {
-  COMPREPLY=($(compgen -W "--all --assume-yes --print-table --help --dry-run $(list_documents)" -- "${COMP_WORDS[$COMP_CWORD]}"))
+  COMPREPLY=($(compgen -W "--all --assume-yes --package --print-table --help --dry-run $(list_documents)" -- "${COMP_WORDS[$COMP_CWORD]}"))
 }
 
 function _list_documents_completions()

--- a/config/packages
+++ b/config/packages
@@ -1,0 +1,5 @@
+# define your own release packages here
+
+CC_PACKAGE[ADV]="ase adv_arc adv_fsp adv_tds reflist"
+CC_PACKAGE[ATE]="ate_cov reflist"
+CC_PACKAGE[ALC]="alc reflist"

--- a/documentation/creating-releases.adoc
+++ b/documentation/creating-releases.adoc
@@ -78,16 +78,18 @@ to be inclusded in the release. The script takes the following arguments.
 [cols="1,3"]
 |===
 | --dry-run       | Don't make acutal changes
+| --package <pkg> | Release all documents in package <pkg>. Packages are defined in `config/packages`.
 | --all           | Release all documents
 | --remote <name> | Push changes to remote repo <name>. Default: origin
 | --local         | Create a local release, do not push changes
 | --assume-yes    | Do not ask for confirmation. DANGEROUS! For use in scripted environment only.
 |===
 
-A typical would look like this:
+Typical calls look like this:
 
 ----
-./scripts/release_documents.sh --dry-run ase adv_tds
+./scripts/release_documents.sh ase adv_tds
+./scripts/release_documents.sh --package ADV --local
 ----
 
 This call creates a release of the Security Target ASE and the Design


### PR DESCRIPTION
Define packages for document releases, such as all ADV documents or all ATE documents. Use predefined packages or customize the list in config/packages.