### PR TITLE
Use suggested "nospace" option on varioref

### DIFF
--- a/common/common-packages.tex
+++ b/common/common-packages.tex
@@ -1,5 +1,6 @@
 \usepackage{amsfonts}
-\usepackage[english,ngerman]{babel,varioref}
+\usepackage[english,ngerman]{babel}
+\usepackage[nospace,english,ngerman]{varioref}
 \usepackage{translations}
 \usepackage{tabularx}
 \usepackage{longtable}


### PR DESCRIPTION
Separate babel and varioref packages